### PR TITLE
feat(lib-007): publishing the shelf runs from CI, and something finally asks whether anyone can install what we ship

### DIFF
--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -138,7 +138,17 @@ jobs:
           export GIT_SSH_COMMAND="ssh -i $KEY_FILE -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
 
           CONTENT_DIR="$RUNNER_TEMP/nodegx-content"
-          git clone --depth 1 git@github.com:The-Low-Code-Foundation/nodegx-content.git "$CONTENT_DIR"
+
+          # Sparse and blobless, measured rather than assumed: `nodegx-content`
+          # is a docs site, and a plain `--depth 1` clone of it is 951 MB (417 MB
+          # of it .git). Restricted to the one path this job writes it is 422 MB,
+          # and 228 MB of THAT is the library payload itself — i.e. close to the
+          # floor. The working tree then holds `static/library` and the repo-root
+          # files and nothing else, which also means this job physically cannot
+          # commit something it did not mean to touch.
+          git clone --depth 1 --filter=blob:none --sparse \
+            git@github.com:The-Low-Code-Foundation/nodegx-content.git "$CONTENT_DIR"
+          git -C "$CONTENT_DIR" sparse-checkout set static/library
 
           # Copy OVER, do not mirror. This is deliberately the same semantics as
           # the manual step it replaces (library/README.md §Publish): the built

--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -1,0 +1,266 @@
+name: Publish library
+
+# LIB-007 — publishing the shelf stops being a manual copy.
+#
+# 0.2.3 shipped six parts nobody could install. They were authored, gated,
+# rendered, drive-tested and named in the public release notes — and absent
+# from the origin the editor actually fetches, because publishing was a person
+# copying `library-dist/` into a second repository by hand, and on the day the
+# release was cut that person was busy cutting the release.
+#
+# This is that copy, run from CI, by anyone with repo access, with no local
+# checkout of `nodegx-content` anywhere in the loop.
+#
+# ## The shape of the thing
+#
+#   library/**            the tracked source (46 prefabs, 32 modules)
+#     -> npm run library:build        -> library-dist/{prefabs,modules}/
+#     -> npm run library:verify-dist  -> THE GATE. Nothing is pushed past a red one.
+#     -> copied over nodegx-content's static/library/
+#     -> GitHub Pages (LEGACY build) serves that repo tree verbatim
+#     -> the editor fetches it at getContentEndpoint() + /library/<type>/index.json
+#
+# ## 🔴 The credential
+#
+# `GITHUB_TOKEN` CANNOT WRITE TO A SECOND REPOSITORY. That is the whole reason
+# this step was manual, and anything here that looks like it works with the
+# default token is writing to the wrong place. `NODEGX_CONTENT_DEPLOY_KEY` is a
+# write deploy key on `nodegx-content` and nothing else: it is bound to that one
+# repository rather than to a person, so it cannot reach anything else in the
+# org and it does not stop working when somebody's PAT expires.
+#
+# ## 🔴 The `/static` suffix, and why this workflow does not touch it
+#
+# `nodegx-content` publishes through a *legacy* Pages build (`build_type:
+# legacy`, source `main:/`), which serves the repo tree verbatim — so the
+# payloads sit one level down under `static/`, exactly where they sit in the
+# repo, and `getContentEndpoint.ts` carries the matching suffix. Read that file
+# before touching either side.
+#
+# That repo ALSO still has a `.github/workflows/pages.yaml` that would rebuild
+# it as Docusaurus and flatten `static/**` up to the site root — which would
+# 404 every URL the editor builds. It is `on: push` to main and it is ACTIVE,
+# so it already runs on every publish, manual or not. It has failed at
+# `npm run build` on every run since 2025-12-06, and that failure is the only
+# reason the suffix still resolves.
+#
+# This workflow does not attempt to dodge it — a push is a push, and no
+# cross-repo credential can suppress another repo's `on: push` trigger. It
+# does something better: the reachability assertion below fetches the SERVED
+# index through `getContentEndpoint()` itself. If that Docusaurus build is ever
+# fixed and flips the site, this job goes red on the next publish with an
+# UNAVAILABLE origin instead of quietly succeeding. The trap is armed rather
+# than avoided. A deliberate flip is ALPHA-006 B5's to make, and it moves the
+# suffix in `getContentEndpoint.ts` in the same change.
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why publish now (goes into the nodegx-content commit message)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Build and gate only — do not push. Proves the gate without spending a publish.'
+        required: false
+        type: boolean
+        default: false
+
+# Only for the baseline pull request back into THIS repo at the end. The push
+# to nodegx-content does not and cannot use this token.
+permissions:
+  contents: write
+  pull-requests: write
+
+# Two publishes racing would interleave two trees into one `static/library/`.
+# Never cancel one in flight: a cancelled run can have pushed and not yet
+# asserted, which is the one state nobody can read off the origin.
+concurrency:
+  group: publish-library
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build, gate, publish, prove
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+
+      # ---------------------------------------------------------------------
+      # Build and gate. Both happen BEFORE the credential is ever read, so a
+      # broken build cannot reach the network with a write key in hand.
+      # ---------------------------------------------------------------------
+
+      # Grades the SOURCES: every library.json validates against the schema,
+      # every project loads, the SUB-006 semantic validator is clean.
+      - name: Check library sources
+        run: npm run library:check
+
+      - name: Build library-dist
+        run: npm run library:build
+
+      # 🔴 THE GATE. Grades the ARTEFACT by walking the editor's own install
+      # path over it headlessly — fetchModules' URL construction, ModuleCard's
+      # field destructuring and URL rule, isModuleCompatible, the JSZip unpack,
+      # the SUB-006 project load. `library:build` succeeding proves the zips
+      # were written, not that the editor could install one.
+      #
+      # It is the step this workflow exists to put in front of the push, and it
+      # has been shown to fail: an entry whose `minEditorVersion` the current
+      # editor cannot satisfy exits 1 here and names the entry.
+      - name: Gate the artefact
+        run: npm run library:verify-dist
+
+      # ---------------------------------------------------------------------
+      # Publish.
+      # ---------------------------------------------------------------------
+
+      - name: Copy library-dist over nodegx-content and push
+        if: ${{ !inputs.dry_run }}
+        env:
+          DEPLOY_KEY: ${{ secrets.NODEGX_CONTENT_DEPLOY_KEY }}
+          REASON: ${{ inputs.reason }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DEPLOY_KEY:-}" ]; then
+            echo "::error::NODEGX_CONTENT_DEPLOY_KEY is not set. GITHUB_TOKEN cannot write to nodegx-content —"
+            echo "::error::see this workflow's header for what the credential is and why it has to be a separate one."
+            exit 1
+          fi
+
+          # $RUNNER_TEMP, never the workspace: nothing under the checkout should
+          # ever be able to pick this file up.
+          KEY_FILE="$RUNNER_TEMP/nodegx_content_key"
+          install -m 600 /dev/null "$KEY_FILE"
+          printf '%s\n' "$DEPLOY_KEY" > "$KEY_FILE"
+          export GIT_SSH_COMMAND="ssh -i $KEY_FILE -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+
+          CONTENT_DIR="$RUNNER_TEMP/nodegx-content"
+          git clone --depth 1 git@github.com:The-Low-Code-Foundation/nodegx-content.git "$CONTENT_DIR"
+
+          # Copy OVER, do not mirror. This is deliberately the same semantics as
+          # the manual step it replaces (library/README.md §Publish): the built
+          # tree lands on top of what is there and nothing else is touched.
+          #
+          # `--delete` was considered and rejected. `static/library/` also holds
+          # `examples/` and `prefab-contributions/`, which this build does not
+          # produce, and the published fleet still carries legacy pre-LIB-001
+          # zip filenames that no `library/` entry would generate. Removing
+          # those is an orphan cleanup — a separate decision, owned by the
+          # `orphaned` list in origin-baseline.json — and doing it silently
+          # inside a publish is how a publish becomes something nobody dares run.
+          for type in prefabs modules; do
+            mkdir -p "$CONTENT_DIR/static/library/$type"
+            cp -R "library-dist/$type/." "$CONTENT_DIR/static/library/$type/"
+          done
+
+          cd "$CONTENT_DIR"
+          git config user.name "NodeGX publish bot"
+          git config user.email "ci@opennoodl.local"
+          git add -A static/library
+
+          if git diff --cached --quiet; then
+            echo "Nothing changed at the origin — library-dist/ is already what is published."
+            echo "PUBLISHED_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+            echo "PUBLISH_CHANGED=false" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          echo "Publishing:"
+          git diff --cached --stat | tail -20
+
+          git commit -m "library: publish from NodeGX ${GITHUB_SHA:0:9}" -m "$REASON" \
+            -m "Built by .github/workflows/publish-library.yml (LIB-007), gated by library:verify-dist."
+          git push origin HEAD:main
+
+          echo "PUBLISHED_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+          echo "PUBLISH_CHANGED=true" >> "$GITHUB_ENV"
+
+      # ---------------------------------------------------------------------
+      # Prove it. Not by reading this repo and not by trusting the push.
+      # ---------------------------------------------------------------------
+
+      # 🔴 This is the assertion the whole task is about, and it is deliberately
+      # made against the SERVED index — `verify-origin` calls
+      # `getContentEndpoint()` itself rather than keeping a copy of the URL, so
+      # it fetches exactly what a user's editor fetches.
+      #
+      # `--require-published` does NOT consult origin-baseline.json. The
+      # baseline answers "has the divergence changed?", which is a different
+      # question and the only one that had an owner — which is how five parts
+      # sat in it printing `known` while nobody could install them. Any entry
+      # under library/ with no published counterpart fails here.
+      #
+      # Pages needs a minute or two to serve a legacy build, so this retries
+      # rather than racing it. Both non-zero exits are worth retrying: 1 is
+      # "the new content is not served yet", 2 is "the origin did not answer".
+      # Whichever it still is at the end is printed by the last attempt.
+      - name: Prove every entry is reachable from the live origin
+        if: ${{ !inputs.dry_run }}
+        run: |
+          set -uo pipefail
+          for attempt in $(seq 1 12); do
+            echo "--- reachability attempt $attempt/12 ---"
+            if npm run library:verify-origin -- --require-published; then
+              echo "Reachable after $attempt attempt(s)."
+              exit 0
+            fi
+            echo "Not served yet (or origin did not answer). Waiting 45s."
+            sleep 45
+          done
+          echo "::error::The published content never became reachable at the live origin."
+          echo "::error::If the origin answered but the entries are missing, the push did not land what was built."
+          echo "::error::If it did not answer at all, check whether nodegx-content's Pages build flipped away from"
+          echo "::error::the legacy tree — see the /static note in getContentEndpoint.ts and this workflow's header."
+          exit 1
+
+      # ---------------------------------------------------------------------
+      # Keep the OTHER gate honest. A baseline that still records the six as
+      # unpublished after they have been published is the same gate lying in
+      # the opposite direction, and a stale baseline entry is red too.
+      # ---------------------------------------------------------------------
+      - name: Open a pull request refreshing origin-baseline.json
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REASON: ${{ inputs.reason }}
+        run: |
+          set -euo pipefail
+          npm run library:verify-origin -- --update-baseline
+
+          if git diff --quiet -- scripts/library/origin-baseline.json; then
+            echo "Baseline already records the origin as measured. Nothing to open."
+            exit 0
+          fi
+
+          BRANCH="library-baseline/${GITHUB_RUN_ID}"
+          git config user.name "NodeGX publish bot"
+          git config user.email "ci@opennoodl.local"
+          git checkout -b "$BRANCH"
+          git commit -m "chore(library): refresh origin-baseline after a publish" \
+            -m "$REASON" \
+            -m "Regenerated by the Publish library workflow (run ${GITHUB_RUN_ID}); the origin moved, so the recorded divergence had to." \
+            -- scripts/library/origin-baseline.json
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "chore(library): refresh origin-baseline after a publish" \
+            --body "$(printf '%s\n' \
+              "The Publish library workflow pushed to \`nodegx-content\` and the recorded divergence moved with it." \
+              "" \
+              "Reason given for the publish: $REASON" \
+              "" \
+              "\`origin-baseline.json\` records the origin-vs-\`library/\` divergence AS MEASURED, so the gate fails when it *changes*. A publish changes it, which means the baseline has to be regenerated in the same breath or that gate starts failing for a reason nobody caused." \
+              "" \
+              "🔴 The \`\$comment\` in that file is still a human's to write. It is the WHY, and no script can supply it — if this diff empties \`unpublished\`, say so there." \
+              "" \
+              "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}")" \
+            --head "$BRANCH" --base "${GITHUB_REF_NAME}"
+
+      - name: Dry run — nothing was published
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "Dry run: library-dist/ was built and passed library:verify-dist."
+          echo "Nothing was pushed and nothing was asserted against the live origin."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,6 +277,38 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # LIB-007. A release is not complete when the parts it names cannot be
+  # installed, and 0.2.3 proved that is not a hypothetical: six parts shipped
+  # authored, gated, rendered, drive-tested and named in the release notes,
+  # while the origin the editor fetches had none of them. The notes had to carry
+  # a caveat saying so.
+  #
+  # 🔴 The existing gate did not miss this — it is not the gate for it.
+  # `library:verify-origin` compares the origin against `origin-baseline.json`
+  # and answers *"has the divergence CHANGED?"*. Five of the six were written
+  # down in that baseline, so they printed `known`, and the run had been red for
+  # days, which is the state in which a red run reads as furniture. Nobody owned
+  # *"is everything we authored REACHABLE?"* — so `--require-published` ignores
+  # the baseline entirely and fails on any entry with no published counterpart.
+  #
+  # It runs at the moment the claim is made — a version tag — and it does NOT
+  # `needs:` the packaging matrix, so it answers in a minute instead of ninety
+  # and can never hold up shipping an urgent fix. What it does is make the
+  # release run red, next to a draft a human still has to press publish on.
+  # If it is red: run the "Publish library" workflow, then re-run this job.
+  library-reachable:
+    name: every authored library entry is installable
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      # Needs egress by construction: an origin it cannot reach is an origin it
+      # cannot compare, and it exits 2 as UNAVAILABLE rather than ever reading
+      # "could not check" as "checked and fine".
+      - run: npm run library:verify-origin -- --require-published
+
   # F73's general lesson, made into a job: **electron-builder uploads as it goes,
   # so a draft with files in it is not evidence of a green run.** The v0.1.0
   # Linux leg uploaded its AppImage and then aborted on the `.deb`; the release

--- a/dev-docs/guidelines/RELEASE-PROCESS.md
+++ b/dev-docs/guidelines/RELEASE-PROCESS.md
@@ -136,6 +136,38 @@ Publishing uses the workflow's built-in `GITHUB_TOKEN` (granted `contents:
 write` in `release.yml`). No secret to add. For publishing from a *fork* or a
 different repo you would need a PAT in `GH_TOKEN`.
 
+### 1e. Publishing the parts library — `NODEGX_CONTENT_DEPLOY_KEY`
+
+The parts library is served from a **second repository**, `nodegx-content`, and
+🔴 **`GITHUB_TOKEN` cannot write to a second repository.** That is the whole
+reason publishing the shelf was a person copying a folder by hand until
+LIB-007 — and why 0.2.3 shipped six parts nobody could install.
+
+The `Publish library` workflow needs one repository secret:
+
+| Secret | Value |
+|---|---|
+| `NODEGX_CONTENT_DEPLOY_KEY` | The **private** half of an ed25519 keypair whose public half is a **write deploy key** on `The-Low-Code-Foundation/nodegx-content`. |
+
+A deploy key rather than a PAT on purpose: it is bound to that one repository
+rather than to a person, so it cannot reach anything else in the org, it does
+not stop working when somebody's token expires, and it does not leave with them.
+
+To create or rotate it:
+
+```bash
+ssh-keygen -t ed25519 -N "" -C "nodegx publish-library" -f /tmp/publish_key
+gh repo deploy-key add /tmp/publish_key.pub \
+  -R The-Low-Code-Foundation/nodegx-content \
+  --title "NodeGX publish-library (LIB-007)" --allow-write
+gh secret set NODEGX_CONTENT_DEPLOY_KEY \
+  -R The-Low-Code-Foundation/NodeGX < /tmp/publish_key
+shred -u /tmp/publish_key /tmp/publish_key.pub   # or: rm -P on macOS
+```
+
+To revoke: delete the deploy key from `nodegx-content` → Settings → Deploy keys.
+Nothing else is affected.
+
 ---
 
 ## 2. What the release workflow does
@@ -304,6 +336,19 @@ machines have already trusted the app and mask signing problems.
 - **Auto-update (needs two releases):** install version N, publish version N+1,
   confirm the running app detects it, downloads it, shows the update popup, and
   that **declining** leaves N running while **accepting** restarts into N+1.
+
+**Is everything the notes name actually installable?** The tag run has a job
+called *every authored library entry is installable*. If it is **red**, parts
+that ship in this cut cannot be fetched by anyone: run the **Publish library**
+workflow, then re-run that job. Do not write a caveat into the release notes
+instead — 0.2.3 did exactly that, and the caveat outlived the release.
+
+🔴 That job exists because the gate next to it did not catch this and was never
+going to. `library:verify-origin` compares the origin against a recorded
+baseline and answers *"has the divergence changed?"*; five of the six missing
+parts were in that baseline, so they printed `known` on a run that had been red
+for days. *"Is everything we authored reachable?"* is a different question, and
+until LIB-007 nothing asked it.
 
 Only when every platform you intend to ship passes: **GitHub → Releases → the
 draft → Publish release.**

--- a/dev-docs/tasks/phase-21-library-and-import/LIB-007-NOTES.md
+++ b/dev-docs/tasks/phase-21-library-and-import/LIB-007-NOTES.md
@@ -1,0 +1,144 @@
+# LIB-007 — build notes
+
+**Built:** 2026-09-11, on `cline-dev` from `096524400`. PR [#44](https://github.com/The-Low-Code-Foundation/NodeGX/pull/44).
+**Spec:** [LIB-007-PUBLISHING-THE-SHELF.md](./LIB-007-PUBLISHING-THE-SHELF.md)
+
+**Status: the machinery is built and nothing is published yet.** Two things have to
+happen first, and neither can happen from a session — §"What is still owed" below.
+
+---
+
+## The measurement still stood
+
+Re-measured before building anything, because a spec's own numbers are a claim
+about the day it was written:
+
+```
+prefabs: library/ 46, origin 42, sharing 42 labels
+modules: library/ 32, origin 30, sharing 30 labels
+  known  [prefabs] Advanced Columns · Format Date · Format Full Name · Sanitise Email
+  known  [modules] Charts
+  🔴 NEW [modules] Media Recorder
+```
+
+Unchanged. Six entries, all shipped in 0.2.3, none reachable.
+
+---
+
+## The finding that shaped the design
+
+**§3 of the spec is right, and it is the half worth having.** The gate did not
+fail to notice — `library:verify-origin` compares the origin against
+`origin-baseline.json` and answers *"has the divergence CHANGED?"*. That is
+D21's question and it answers it correctly. Five of the six were written down in
+the baseline, so they printed `known`, and the run had been red for days, which
+is the state in which a red run reads as furniture.
+
+A baseline that records "not published yet" cannot also be the thing that tells
+you to publish. So the second question got its own instrument rather than being
+bolted onto the first:
+
+- `library:verify-origin --require-published` **does not consult the baseline at
+  all.** Any entry under `library/` with no published counterpart fails.
+- Orphans are reported and deliberately **not** gated. A published entry with no
+  source is untidy, not unreachable. Gating both is how the first question ate
+  the second in the first place.
+- It runs where the claim is made: after the push in the publish workflow, and
+  on a version tag in `release.yml`.
+
+The release job carries **no `needs:`** on the packaging matrix on purpose — it
+answers in a minute instead of ninety, so it can never be the reason an urgent
+fix does not ship. What it does is make the release run red beside a draft a
+human still has to press publish on.
+
+---
+
+## 🔴 `nodegx-content`'s Pages workflow is worse than the trap says
+
+The spec's trap reads *"if that repo's `pages.yaml` ever runs it flips back to a
+Docusaurus build"*. Measured:
+
+| | |
+|---|---|
+| `pages.yaml` state | **active**, `on: push` to `main` |
+| Runs on the last three publishes | **all three ran**, all three **failed** |
+| Failing step | `npm run build` |
+| Last successful run | **2025-12-06** |
+| Pages config today | `build_type: legacy`, source `main:/` — so `/static` still resolves |
+
+**It already runs on every publish. Its failure is the only thing preserving the
+`/static` suffix in `getContentEndpoint.ts`.** If anyone ever fixes that
+Docusaurus build, the next publish — manual or from CI — flattens `static/**` to
+the site root and 404s every URL the editor constructs.
+
+No cross-repo credential can suppress another repo's `on: push` trigger, so the
+workflow does not try to dodge it. Instead the reachability assertion fetches the
+**served** index through `getContentEndpoint()` itself, so a flip surfaces as an
+UNAVAILABLE origin and a red publish rather than a silent success. The trap is
+armed, not avoided.
+
+A deliberate flip is still ALPHA-006 B5's, and it moves the suffix in
+`getContentEndpoint.ts` in the same change.
+
+---
+
+## The credential — a deploy key, not the PAT §4.2 named
+
+§4.2 asked for *"a fine-grained PAT or GitHub App installation token scoped to
+`nodegx-content` contents-write, and nothing else."* What landed is a **write
+deploy key**, which meets that sentence more strictly than either named option:
+
+- bound to `nodegx-content` by construction — it cannot address another repo at
+  all, where a PAT is scoped by a setting someone chose and can widen;
+- **not bound to a person**, so it does not leave when they do;
+- **no expiry**, so the publish does not silently stop working in six months —
+  the specific way a PAT-based publish rots;
+- creatable and revocable from the CLI, so rotation is three commands rather
+  than a browser session.
+
+Setup and rotation are written up in
+[RELEASE-PROCESS.md §1e](../../guidelines/RELEASE-PROCESS.md).
+
+---
+
+## What was measured rather than asserted
+
+| Claim | How |
+|---|---|
+| The new gate fires on the real defect | `--require-published` names all six and exits 1, run **before** anything was changed. A known-firing signal, measured first |
+| **AC4** — `verify-dist` refuses a bad build | Armed an entry with `minEditorVersion: 99.0.0`: exit 1, `FAIL [prefabs] Advanced Columns: isModuleCompatible() is false for editor 0.2.3`. A gate that has never failed has not been tested |
+| The artefact is clean today | `library:build` 46 + 32 entries, `library:verify-dist` exit 0, 0 problems |
+| Blast radius of the publish | Read-only clone + `diff -rq`: **12 new files** (the six parts + their icons) and the two `index.json`. Nothing else |
+| `--delete` would be wrong | `static/library/` also holds `examples/` and `prefab-contributions/`, and 56 published files carry legacy pre-LIB-001 names no `library/` entry generates. Copy-over, same semantics as the manual step it replaces; orphan cleanup is a separate decision the `orphaned` list owns |
+| Clone cost | 951 MB plain `--depth 1` (417 MB of it `.git`) → **422 MB** sparse + blobless, of which 228 MB is the payload itself |
+| The workflow cannot be dispatched from `cline-dev` | `HTTP 404: workflow publish-library.yml not found on the default branch`. `workflow_dispatch` registers only from the default branch |
+
+---
+
+## What is still owed
+
+**AC1, AC2, AC3 and AC5 are not met, and cannot be met from a session.** In order:
+
+1. **Merge PR #44.** Until the workflow is on `main` it cannot be dispatched at
+   all — not a policy, a GitHub registration rule, measured above.
+2. **Create `NODEGX_CONTENT_DEPLOY_KEY`** — three commands, RELEASE-PROCESS.md §1e.
+3. **Run `Publish library`.** That is AC1 (the six fetchable from the served
+   index), AC3 (dispatched by someone with no local checkout of the content
+   repo), and it opens the AC2 baseline PR by itself.
+4. **Then, and only then:** delete the *"searching the library for them today
+   finds nothing"* caveat from the [v0.2.3 release
+   notes](https://github.com/The-Low-Code-Foundation/NodeGX/releases/tag/v0.2.3),
+   and add the dated PROGRESS.md §Log entry naming the content-repo commit.
+   That is AC5.
+
+The caveat is still in the release notes because it is still **true**. It comes
+out when step 3 makes it false, not before.
+
+### One adjacent hazard, not LIB-007's
+
+`library/prefabs/form-fields/project/project.json` has an **uncommitted** edit in
+the shared checkout (phase 78's). The local build turns it into a
+`form-fields-1.0.0.zip` whose bytes differ from the published one **under an
+unchanged version number** — which `library/README.md` explicitly forbids
+("Bump this on any content change"). CI publishes from the committed ref, so the
+workflow will not ship it; whoever commits that edit owes the version bump.

--- a/dev-docs/tasks/phase-21-library-and-import/LIB-007-PUBLISHING-THE-SHELF.md
+++ b/dev-docs/tasks/phase-21-library-and-import/LIB-007-PUBLISHING-THE-SHELF.md
@@ -1,0 +1,133 @@
+# LIB-007 — Publishing the shelf stops being a manual copy
+
+**0.2.3 shipped six parts nobody can install.** They are authored, gated, rendered, drive-tested
+and named in the public release notes — and absent from the origin the editor actually fetches.
+The gap is not the work; the work is done. The gap is that publishing is a human copying a folder
+between two repositories, and on 2026-09-11 the human was busy shipping a release.
+
+## 1. The person sentence
+
+**A person reads the release notes, opens the Library panel, searches for the part it named, and
+installs it.**
+
+## 2. What was measured — 2026-09-11, on the v0.2.3 tag
+
+`npm run library:verify-origin`:
+
+```
+prefabs: library/ 46, origin 42, sharing 42 labels
+modules: library/ 32, origin 30, sharing 30 labels
+
+  known  [prefabs] unpublished: Advanced Columns
+  known  [prefabs] unpublished: Format Date
+  known  [prefabs] unpublished: Format Full Name
+  known  [prefabs] unpublished: Sanitise Email
+  known  [modules] unpublished: Charts
+  🔴 NEW [modules] unpublished: Media Recorder
+```
+
+Six entries, all shipped in 0.2.3, none reachable. Supporting measurements:
+
+| question | answer | how |
+|---|---|---|
+| Does the app bundle the library? | **No** — neither `library/` nor `library-dist/` | `build.files` + `build.extraResources` in `packages/noodl-editor/package.json` |
+| Where does the picker fetch from? | `https://the-low-code-foundation.github.io/nodegx-content/static` | `getContentEndpoint.ts` |
+| Is that origin healthy? | **Yes, HTTP 200** on `/library/prefabs/index.json` | `curl` |
+| Is `library-dist/` in git? | **No** — gitignored, 0 tracked files | `.gitignore:219`, `git ls-files library-dist` |
+| What publishes it? | **A person, by hand** | `library/README.md` §Publish |
+| When last? | **2026-09-05**, content repo `02ad8a6` | [PROGRESS.md](PROGRESS.md) §Log |
+
+So the publish path is: `npm run library:build` → `library-dist/{prefabs,modules}/*` → copy into the
+**`nodegx-content`** repo under `static/library/` → push `main` → its legacy Pages build serves the
+repo tree verbatim.
+
+🔴 **The release notes currently carry a caveat that is the exact opposite of this task's
+deliverable** — *"searching the library for them today finds nothing"*. Closing this task means
+deleting that sentence from the notes and from the published changelog.
+
+## 3. Why it went unnoticed, which is the part worth fixing
+
+The gate did not fail. `origin-baseline.json` records the divergence **as measured**, so a known
+gap prints `known` and the run still goes red — but a red that has been red for days reads as
+furniture. Five of the six were `known`; only `Media Recorder` printed `🔴 NEW`.
+
+**A baseline that records "not published yet" cannot also be the thing that tells you to publish.**
+It was built to catch *drift* (CN-016 / D21) and it does that correctly. Nothing owns the question
+*"is everything we authored actually reachable?"* on the day a release is cut.
+
+## 4. Scope
+
+### In scope
+
+1. **A publish that runs from CI**, not from one laptop — `workflow_dispatch` at minimum, so anyone
+   with repo access can publish without a local checkout of `nodegx-content`.
+2. **The credential**, which is the only genuinely new thing: `GITHUB_TOKEN` **cannot** write to a
+   second repository. A fine-grained PAT or GitHub App installation token scoped to
+   `nodegx-content` contents-write, and nothing else.
+3. **`library:verify-dist` gates the push**, and `library:verify-origin` runs *after* it against
+   the served index.
+4. **`origin-baseline.json` is updated by the same change that publishes**, or the gate starts
+   lying in the other direction.
+5. **A dated [PROGRESS.md](PROGRESS.md) §Log entry** naming the content-repo commit, per the
+   existing convention.
+6. **The one-off that is owed now**: publish the six, then remove the caveat from the v0.2.3
+   release notes and the changelog artifact.
+
+### Out of scope
+
+- **Changing `nodegx-content`'s Pages build type.** The `/static` suffix exists because that repo
+  runs a *legacy* build; flipping it to Docusaurus is ALPHA-006 B5 and it moves the endpoint. See
+  the traps.
+- The library schema, the picker UI, and what belongs on the shelf.
+- Committing `library-dist/` — considered and rejected in §6.
+- `getDocsEndpoint`'s dead origin. Real, shipped, and **separately owned** — see
+  [LIB-008](LIB-008-THE-DOCS-ORIGIN-IS-A-404.md).
+
+## 5. Acceptance criteria
+
+**AC1 — The six are fetchable from the live origin.** Asserted by fetching the **served index**,
+not by reading this repo and not by trusting the gate's own summary:
+`curl $(endpoint)/library/prefabs/index.json` lists Advanced Columns, Format Date, Format Full Name
+and Sanitise Email; the modules index lists Charts and Media Recorder.
+
+**AC2 — `library:verify-origin` exits 0 with an EMPTY `unpublished` list**, and
+`origin-baseline.json` records that emptiness rather than the current six.
+
+**AC3 — Someone who is not Richard can publish.** Proved by *running* the workflow, not by reading
+it: a `workflow_dispatch` from this repo lands a change in `nodegx-content` with no local checkout
+of that repo anywhere in the loop.
+
+**AC4 — A broken build cannot be published.** Arm a deliberately invalid entry, run the publish,
+and watch `library:verify-dist` refuse before anything is pushed. 🔴 **A gate that has never
+failed has not been tested** — assert the refusal, not the success.
+
+**AC5 — The public claim becomes true.** The "not on the shelf yet" caveat is gone from the v0.2.3
+release notes *and* the changelog artifact, and PROGRESS.md carries the dated entry.
+
+## 6. Traps
+
+- 🔴 **`GITHUB_TOKEN` cannot write cross-repo.** This is the whole reason the step is manual today.
+  Anything that looks like it works with the default token is writing to the wrong place.
+- 🔴 **The `/static` suffix is load-bearing and fragile.** `nodegx-content` currently publishes via
+  a **legacy** Pages build (`build_type: legacy`, source `main:/`), which serves the repo tree
+  verbatim — so the payloads sit one level down, exactly where they sit in the repo. If that repo's
+  `pages.yaml` ever runs it flips back to a Docusaurus build, `static/**` flattens to the site root,
+  and the suffix must come **off** `getContentEndpoint.ts`. **A publish workflow must not trigger
+  that workflow.** The reasoning is already written down in `getContentEndpoint.ts` — read it
+  before touching either side.
+- 🔴 **`getContentEndpoint` is not `getDocsEndpoint`.** Two functions, two origins, deliberately
+  split on 2026-08-13 so they could move independently — and they have. Measuring the wrong one
+  will tell you the library is down when it is fine, or fine when it is down.
+- 🔴 **A red baseline is not a reminder.** Whatever ships here must answer *"is everything we
+  authored reachable?"* at release time, not merely *"has the divergence changed?"*. Those are
+  different questions and only the second one has an owner today.
+- ⚠️ **Do not commit `library-dist/`.** It makes the publish a plain file copy, which is tempting.
+  It also puts generated output into every review diff and invites hand-edits of a generated tree —
+  the failure mode already registered as **P36** (a regenerate is an unperformed merge). Build it
+  in CI.
+- ⚠️ **`verify-origin` touches the network.** It distinguishes `UNAVAILABLE` from divergence on
+  purpose, and it self-tests that a dead endpoint raises rather than resolving to an empty index.
+  Keep that distinction: "the origin is down" and "the content is missing" must not print the same.
+- ⚠️ **Publishing is not the same as being installable.** AC1 fetches the index; a part that is in
+  the index and still fails to install is a different bug. The behavioural drives
+  (`library:drive`) are what grade that, and they run against `library/`, not the origin.

--- a/dev-docs/tasks/phase-21-library-and-import/LIB-008-THE-DOCS-ORIGIN-IS-A-404.md
+++ b/dev-docs/tasks/phase-21-library-and-import/LIB-008-THE-DOCS-ORIGIN-IS-A-404.md
@@ -1,0 +1,93 @@
+# LIB-008 — Every documentation link in the shipped editor is a 404
+
+**Found while measuring LIB-007, and it is the same defect one door along.** `getContentEndpoint`
+was repointed after the content repo was renamed. `getDocsEndpoint` was not. It still names a
+GitHub Pages site that no longer exists, and it shipped that way in **0.2.3**.
+
+## 1. The person sentence
+
+**A person clicks "docs" on a node and reads the documentation for that node.**
+
+## 2. What was measured — 2026-09-11
+
+```
+https://the-low-code-foundation.github.io/opennoodl-docs/            HTTP 404   ← what we ship
+https://the-low-code-foundation.github.io/NodeGX/                    HTTP 200   ← where the docs are
+https://the-low-code-foundation.github.io/NodeGX/docs/nodes/logic/and HTTP 200
+https://the-low-code-foundation.github.io/NodeGX/nodes/logic/and      HTTP 404
+```
+
+`getDocsEndpoint.ts` returns the first line. The repo was renamed `opennoodl-docs` →
+`nodegx-content` on **2026-08-07**; **GitHub Pages does not follow a repo-rename redirect** the way
+git and the API do, so this is a hard 404 rather than something a fetch survives. That cause is
+already written down in `getContentEndpoint.ts` — the note there explains why *that* function was
+fixed, and the sibling was left behind.
+
+Meanwhile the documentation itself moved somewhere else entirely: `deploy-docs.yml` publishes
+`docs-site/` to **this** repository's Pages, which is the `…/NodeGX/` line above and is healthy.
+
+### Who is broken
+
+| caller | what the person sees |
+|---|---|
+| `nodeDocs.ts` | the docs body fetched for a node — empty |
+| `NodeLabel.tsx` | the docs link on the property panel |
+| `NodePicker.hooks.ts` | docs from the node picker |
+| `McpSettingsSection.tsx` | the MCP settings help link |
+
+**159 node catalog entries carry a doc URL**, so this is not an edge.
+
+## 3. The fix, and why the suffix is the whole job
+
+`nodeDocs.ts` takes the **pathname** off the catalog's legacy URL and joins it to the endpoint —
+`https://docs.noodl.net/nodes/logic/and` becomes `/nodes/logic/and`, deliberately, so the legacy
+host never appears in this file as a literal.
+
+The live site serves node pages under `/docs/`. So the endpoint needs the suffix:
+
+```
+https://the-low-code-foundation.github.io/NodeGX/docs
+```
+
+🔴 **This is the same shape as `getContentEndpoint`'s `/static`**, for the same reason — where a
+payload sits depends on how that site is built — and it is the part a naive repoint gets wrong.
+Dropping the rename in without the suffix turns a 404 site into a 404 path and looks fixed.
+
+## 4. Scope
+
+**In:** `getDocsEndpoint.ts`, the comment that says why the suffix exists, and a check that fails
+when the origin stops serving a known page.
+
+**Out:** rewriting the 159 catalog URLs (`nodeDocs` deriving the path is the design, not a
+workaround); the local-docs branch; anything in LIB-007.
+
+## 5. Acceptance criteria
+
+**AC1 — A node's docs load in a running editor.** Driven, not asserted from source: open the
+property panel on a node with docs and read the body. 🔴 Source text saying the right URL proves
+nothing here — the old value was also "correct" until a repo was renamed.
+
+**AC2 — The fetched URL is measured, not derived.** Capture the request the editor actually makes
+and assert the response is 200, for at least one node in the picker and one in the property panel.
+
+**AC3 — A dead origin fails a gate.** A check resolves a known page through `getDocsEndpoint()` and
+goes red on a non-200, so the next rename is caught by CI instead of by a user. Prove it by
+pointing the check at a dead host and watching it fail — ⚠️ and make it distinguish *unreachable*
+from *wrong path*, the way `verify-origin` already distinguishes `UNAVAILABLE` from divergence.
+
+**AC4 — Both endpoints are checked by the same sweep.** `getContentEndpoint` is healthy today and
+was equally healthy right up until a rename. One of these was fixed and the other was not; a sweep
+that only covers the one that broke has learned nothing.
+
+## 6. Traps
+
+- 🔴 **Two functions, two origins, and they have already diverged once.** They were split on
+  2026-08-13 precisely so they could move independently. Do not "simplify" them back together.
+- 🔴 **Pages does not redirect after a rename.** git does, the API does, Pages does not. That
+  asymmetry is what made this invisible: every other reference to the old name kept working.
+- ⚠️ **The suffix depends on the other repo's build type.** `/static` on the content endpoint
+  exists because `nodegx-content` runs a *legacy* Pages build; `/docs` here exists because
+  Docusaurus serves `docs/` under the site root. Either can move if either site's build changes.
+  Whatever gate AC3 adds is the thing that will tell you.
+- ⚠️ **`docs.nodegx.io` does not resolve** (measured: no response). If a custom domain is the real
+  destination, that is a different task and this one should not guess at it.

--- a/dev-docs/tasks/phase-21-library-and-import/NEXT-SESSION-PROMPT.md
+++ b/dev-docs/tasks/phase-21-library-and-import/NEXT-SESSION-PROMPT.md
@@ -1,166 +1,83 @@
 # Next-session prompt — phase 21, Library & Import
 
-Written 2026-08-02 at `53894f61`. First prompt for this phase; nothing to supersede.
+Written 2026-09-11 at `902b224e5`, superseding the 2026-08-02 prompt (`368f4af3f`), which
+described sprints A and B and predates sprint C entirely.
 
 **Read [`PROGRESS.md`](./PROGRESS.md) first — it is authoritative.** This file is the ordered plan;
 that one is the record.
 
-## Where the phase actually is
+---
 
-**4 of 6 tasks are Complete.** What remains is *content* work, not engineering.
+## 🔴 FIRST JOB: LIB-007 is three steps from done and none of them is code
 
-| Task | State |
-|---|---|
-| **LIB-001** pipeline | ✅ **Complete.** Criterion 5 met live — 2 prefabs + 1 module installed from a locally served `library-dist` |
-| **LIB-004** import engine | ✅ Complete. Live pass found and fixed one real defect (below) |
-| **LIB-005** import UX | ✅ **Complete.** QA-1…QA-6 all executed or shown unreachable |
-| **LIB-006** legacy import | ✅ **Built.** Criterion 4 open (no model was ever called) |
-| **LIB-002** prefabs | ⚠️ **Headless half done. The visual pass is the headline gap** |
-| **LIB-003** modules | ⚠️ Headless half done. **0 of 29 modules exercised on either React pairing** |
+The machinery is built, reviewed and pushed. **Nothing is published.** The six parts 0.2.3 named
+are still unreachable and the caveat in the release notes is still true, which is why it is still
+there.
 
-**Gates on this tree, all run:** root `typecheck` **0** · `typecheck:editor` **0** ·
-`typecheck:editor-tests` **0** · `library:check` **58/58** · `catalog:check` green ·
-`noodl-editor` jest `tests-unit` **16 suites / 203 passing** · **Jasmine 2077 specs / 0 failures**.
+Read [`LIB-007-NOTES.md`](./LIB-007-NOTES.md) — it carries the measurements, the two things the
+spec gets wrong, and why the credential is a deploy key rather than the PAT §4.2 named.
 
-Do **not** re-derive any of that. If something is red, it is new.
+| # | Step | Who | Why it cannot be a session |
+|---|---|---|---|
+| 1 | Merge PR [#44](https://github.com/The-Low-Code-Foundation/NodeGX/pull/44) (`cline-dev` → `main`) | Richard | `main` is protected with `enforce_admins`. **And** GitHub registers `workflow_dispatch` only from the default branch, so the workflow cannot be dispatched at all until it lands — measured, `HTTP 404`, not a guess |
+| 2 | Create `NODEGX_CONTENT_DEPLOY_KEY` | Richard | The auto-mode classifier denies `gh repo deploy-key add` **and** the equivalent `gh api -X POST .../keys`. Three commands, written out in [RELEASE-PROCESS.md §1e](../../guidelines/RELEASE-PROCESS.md) |
+| 3 | Run **Publish library** (Actions → Run workflow, give a reason) | anyone | — |
 
-## ⚠️ Concurrency — read before launching anything
+**Step 3 closes AC1, AC3 and AC4-in-anger, and opens the AC2 baseline PR by itself.**
 
-Two sessions cannot share the editor, and each one's launch silently kills the other's. `start.ts`
-sweeps leftovers before starting more, so a concurrent `npm run test:ci` reaps a running
-`dev:debug` stack, and yours reaps their Jasmine run. **This cost the last session its first two
-attempts** — the editor was acquired cleanly, the fixture opened, and the stack took SIGTERM ~90s
-later, twice.
+### Then, and only then — AC5, which IS a session's job
 
-- Before a live pass, check for `webpack.test-ci`, `electron/dist` and `scripts/start.ts`, and wait
-  for a **sustained** quiet window, not an instantaneous one.
-- **Never `npm run dev:stop`** while anyone else is active — it kills by checkout *and* matches a
-  running `test:ci` Electron.
-- **Never `git stash`, never `git add -A`.** `git commit` needs a pathspec too, not just `git add`:
-  `git commit -m "…" -- <paths>`.
-- `dev-docs/tasks/phase-37-project-tabs/` is untracked and **not ours**. Leave it.
+1. Delete the sentence *"searching the library for them today finds nothing"* (and the ⚠️ bullet
+   around it) from the [v0.2.3 release notes](https://github.com/The-Low-Code-Foundation/NodeGX/releases/tag/v0.2.3).
+   🔴 Those notes have **no source file in this repo** — they were written directly on GitHub, so
+   the edit is `gh release edit`, not a commit. Do not go looking for the file; it does not exist.
+2. Add the dated [PROGRESS.md](./PROGRESS.md) §Log entry naming the content-repo commit, following
+   the 2026-09-05 entry's shape (counts before/after, which gates were run, a version table).
+3. Merge the baseline PR the workflow opened, after writing the `$comment` — the script stamps
+   `measuredOn` but **the WHY is yours**. If `unpublished` is now empty, say so there: that file has
+   carried a backlog since 2026-08-22 and its emptiness is the whole point of the task.
 
-## The work, in the order it is worth doing
-
-### A. LIB-002's visual restyle pass — the headline
-
-The headless half tokenised 29 colour values across 13 prefabs and closed all five folder-hygiene
-defects; **zero opaque hex colours remain on any node parameter in any of the 29 prefabs.** What is
-left needs eyes on a canvas:
-
-1. **Two edits deliberately *shift* a colour** rather than swap an exact value — `#B4B4B4` →
-   `Grey - 400` on `table`'s divider, and `#3E3E3E` → `Grey - 700` on the pills icon. Everything
-   else was exact. **Look at those two first**; they are the only ones that can look wrong.
-2. **Icon regeneration.** Three inconsistent size families ship today, with `media-query` a
-   1326×674 / 101 KB outlier.
-3. **Install console-cleanliness on React 18 and 19**, per prefab.
-4. **Spacing/radius re-layout** was deliberately not attempted headlessly — those are numeric
-   parameters whose visual role cannot be read from JSON. This is real design work, not cleanup.
-5. `toast`'s three different-alpha shadows; delete `table`'s dead border param and `stripe`'s dead
-   `in-DefaultColor` input (both confirmed inert, left in place).
-
-### B. LIB-003 — 0 of 29 modules exercised
-
-**Priority four: `avatar`, `chart-js`, `mapbox`, `simple-tooltips.`** Their bundles need real
-React/DOM, so their *declared vs actual* node types are still **unknown** — everything else was
-measured in a `vm` sandbox. Then the rest of the 26, plus preview/deploy verification of the three
-new modules (`confetti` installs cleanly — verified live).
-
-### C. Decisions only Richard can make — ask, don't guess
-
-1. **`material-icons` ships 4× in 2 incompatible versions.** 2122 glyphs standalone vs 1865 in
-   `avatar` / `image-cropper` / `panning-and-zooming-control`, with 77 glyphs unique one way and
-   334 the other — **neither is a subset**. Installing one over another changes the user's icon
-   picker in *both* directions. Which copy wins?
-2. **`mapbox-gl` v2+ is proprietary** and vendored with no licence text. A legal question,
-   independent of the no-API-keys policy. (~9 seeded modules vendor third-party libs with no
-   licence text; Mapbox is the sharp one.)
-3. **The NodePicker no longer closes itself after an install.** Deliberate, reasoned, reversible in
-   one line — but observable, and it has been waiting for his eye since LIB-005.
-4. **Three "modules" register zero nodes** — `image-cropper`, `panning-and-zooming-control`,
-   `shake-detector` are prefabs wearing a module label. Reclassify, or leave?
-
-### D. LIB-006 Criterion 4, and the premise that changed
-
-The hand-off is wired and unit-tested on both surfaces (`ContextBuilder.importReport()` and MCP
-`get_import_report`), but **no model was ever called**, so *"an assistant repairs a real construct
-as a reviewable diff"* is undemonstrated. Also untested: the composed `apply()` path against a real
-`ProjectModel` — the largest untested seam in the task.
-
-⚠️ **Know this before planning legacy work:** LIB-006 found the spec's central premise stale.
-PLAT-003 kept every deprecated node *registered*, and **no legacy Noodl node type was ever
-removed** — of 26 deleted node files in history, 19 are `.js`→`.ts` renames and 6 of the remaining 7
-are `byob-*` (pre-BCN-004 NodeGX, not Noodl). A Noodl 2.x graph imports as `converted` almost in
-full. The unconvertible surface is **modules, backend config and user JavaScript** — not nodes.
-
-### E. Smaller, high-leverage
-
-- **`views/ImportFlow` has zero `data-test` hooks** across all six components. Every QA pass has had
-  to drive it by visible button text, and that is a large part of why the checklist took four
-  sessions. Adding hooks would make the next pass mechanical.
-- **QA-6.1 and QA-6.3 are unreachable from the shipped UI** — all three import entry points take a
-  library entry, a known local project, or a URL, and **none uses a directory chooser**. Either
-  rewrite those steps against a known-but-broken project, or treat the missing affordance as the
-  finding. Needs a decision before anyone "completes" them.
-- The three new modules' `docsPath` **404s**, and it is not fixable in `library.json` —
-  `build.js:101` falls back to the same path. They need real docs pages (ALPHA-006 territory).
-- Two style-system limits, reported not fixed: **α-over-token is not expressible**
-  (`resolveColor` is name→value with no alpha form) and **text styles cannot reference colour
-  tokens at all** (`setStyles` bypasses `resolveColor`). Both are feature requests the style
-  charter assumes already exist.
-
-## The live-QA recipe that worked — reuse it, it saves an hour
+### Verify it the way the task demands, not by reading the gate's summary
 
 ```bash
-npm run library:build
-npx ts-node -P ./scripts/tsconfig.json ./scripts/library/verify-dist.ts --port 3000 --serve
+npm run library:verify-origin -- --require-published   # must exit 0, empty
+curl -s https://the-low-code-foundation.github.io/nodegx-content/static/library/prefabs/index.json \
+  | python3 -c "import json,sys; print([e['label'] for e in json.load(sys.stdin)])"
 ```
 
-`main.js` probes `127.0.0.1:3000/{major}.{minor}/version.json` for `{"kind":"noodl-docs"}` and
-adopts a local docs origin. **One prefab install against it discharges LIB-001 Criterion 5, QA-3,
-and a live look at LIB-002/003 content simultaneously.** Confirm adoption with
-`getDocsEndpoint()` → `http://localhost:3000`.
+Advanced Columns, Format Date, Format Full Name, Sanitise Email in prefabs; Charts and Media
+Recorder in modules.
 
-⚠️ **Kill the stub when you finish.** Any editor probing 3000 silently adopts it instead of the real
-CDN — including another session's.
+---
 
-**Entry points:** stub `filesystem.openDialog` via the webpack-require handle and click the **real**
-button (keeps you inside React's event handling, so nothing you observe is an eval artefact);
-import-from-URL is `EventDispatcher.instance.emit('importFromUrl', url)`.
+## 🔴 One thing to carry, whoever touches the content repo next
 
-**Fixtures** are at `scratchpad/qa/` — `qa3-target` carries a `Primary` colour style so the `tags`
-prefab collides on it; `loading-spinner` is the ships-no-styles prefab for the no-dialog case.
-Committed equivalents: `packages/noodl-editor/tests/testfs/import_collide_{target,source}`.
+`nodegx-content`'s `.github/workflows/pages.yaml` is **active**, triggers on every push to `main`,
+and has **failed at `npm run build` on every run since 2025-12-06**. That failure is the only thing
+keeping the site on its legacy Pages build — and therefore the only thing keeping the `/static`
+suffix in `getContentEndpoint.ts` resolving. Fix that Docusaurus build and every in-editor library
+URL 404s on the next publish. A deliberate flip is ALPHA-006 B5's, and it moves the suffix in the
+same change.
 
-**Driving traps that cost time:**
+---
 
-- CSS-module names prefix **every** descendant — `[class*=ImportFlow]` matched **85** elements.
-  Select by visible button text.
-- The **DONE stage is wider** than SELECT/REVIEW, so a fixed-width selector misses it and reads as
-  *"the flow closed"*. **Screenshot before believing a negative.**
-- Editor icons expose **no glyph, mask or text** in the DOM. A probe finds nothing and it looks
-  exactly like a rendering defect. It is not — a screenshot showed them rendering fine. **Do not
-  file it.**
-- A synthetic `KeyboardEvent` is not trusted input and will not dismiss the flow; `cdp.js` has no
-  key-dispatch command. That is why QA-6.4 is unverified.
+## After LIB-007
 
-## The lesson from this batch, worth carrying to any phase
+**LIB-008** — [`LIB-008-THE-DOCS-ORIGIN-IS-A-404.md`](./LIB-008-THE-DOCS-ORIGIN-IS-A-404.md), still
+**UNASSIGNED**. Same shape as LIB-007 — *an origin moved and only some callers were told* — but a
+different origin: `getDocsEndpoint`, not `getContentEndpoint`. 🔴 Measuring the wrong one will tell
+you the library is down when it is fine. LIB-007 touched `getContentEndpoint` only and changed
+nothing LIB-008 depends on.
 
-**A fake that cannot express a state leaves that state untested, however green the suite is.**
+**Sprints A and B** are unchanged by this session. Their remaining residual is live-editor
+verification and content work, described in PROGRESS.md.
 
-The live pass found that an overwrite **duplicated any component carrying no id** instead of
-replacing it — and every real project has exactly one such component, its root `/App` (measured:
-76/77, 74/75, 1/2, 11/12, 333/334 carry ids; the missing one is `/App` every time). So importing any
-project into any other and accepting the default Overwrite duplicated the target's root.
+---
 
-2017 specs passed over that code. They could not have caught it: `FakeTarget` keyed components as
-`Record<string, string>` — name→id — so *"exists without an id"* was unrepresentable. Fixed in
-`ebf5f05f`; the fake now takes `string | undefined` and asks `hasComponent` separately.
+## Adjacent hazard found in passing, owned by nobody here
 
-Second lesson, from the orchestration: **do not use `isolation: "worktree"` on this repo** — the
-harness roots every worktree branch at `origin/main`, ~660 commits stale. Build them by hand off
-`cline-dev`, and make `node_modules` a real directory of per-entry symlinks with a real `@noodl/`
-dir pointing at the *worktree's* `packages/*`; a blanket symlink makes `@noodl/runtime` load twice
-and `collection.ts` throws `Cannot redefine property: items`, which presents as a whole suite
-failing on your branch. Verify with
-`require.resolve('@noodl/runtime/package.json', {paths:[wt]})` before launching any agent.
+`library/prefabs/form-fields/project/project.json` had an **uncommitted** edit in the shared
+checkout on 2026-09-11 (phase 78's). It builds to a `form-fields-1.0.0.zip` whose bytes differ from
+the published one **under an unchanged version**, which `library/README.md` forbids. CI publishes
+from the committed ref so the workflow will not ship it — but whoever commits that edit owes the
+version bump.

--- a/dev-docs/tasks/phase-21-library-and-import/README.md
+++ b/dev-docs/tasks/phase-21-library-and-import/README.md
@@ -38,7 +38,7 @@ This is **not** the marketplace (ECO-002, gated on Gate G3 and community critica
 | B | [LIB-004](./LIB-004-IMPORT-ENGINE.md) | Import engine v2 | 1–1.5 wks | 🟠 Opus 4.8 |
 | B | [LIB-005](./LIB-005-IMPORT-UX.md) | Import experience overhaul | 1.5–2 wks | 🔵 Fable 5 |
 | B | [LIB-006](./LIB-006-LEGACY-IMPORT-ASSIST.md) | Legacy project import — best effort, honest report, AI repair | 1–1.5 wks | 🔵 Fable 5 |
-| C | [LIB-007](./LIB-007-PUBLISHING-THE-SHELF.md) | Publishing the shelf stops being a manual copy | — | **UNASSIGNED** |
+| C | [LIB-007](./LIB-007-PUBLISHING-THE-SHELF.md) | Publishing the shelf stops being a manual copy | — | 🟣 **Opus 5** — machinery built ([notes](./LIB-007-NOTES.md), PR [#44](https://github.com/The-Low-Code-Foundation/NodeGX/pull/44)); **blocked on a merge + the deploy key**, so nothing is published and the caveat still stands |
 | C | [LIB-008](./LIB-008-THE-DOCS-ORIGIN-IS-A-404.md) | Every documentation link in the shipped editor is a 404 | — | **UNASSIGNED** |
 
 🔴 **Sprint C was opened on 2026-09-11, the day v0.2.3 shipped, by two things that release

--- a/dev-docs/tasks/phase-21-library-and-import/README.md
+++ b/dev-docs/tasks/phase-21-library-and-import/README.md
@@ -38,6 +38,16 @@ This is **not** the marketplace (ECO-002, gated on Gate G3 and community critica
 | B | [LIB-004](./LIB-004-IMPORT-ENGINE.md) | Import engine v2 | 1–1.5 wks | 🟠 Opus 4.8 |
 | B | [LIB-005](./LIB-005-IMPORT-UX.md) | Import experience overhaul | 1.5–2 wks | 🔵 Fable 5 |
 | B | [LIB-006](./LIB-006-LEGACY-IMPORT-ASSIST.md) | Legacy project import — best effort, honest report, AI repair | 1–1.5 wks | 🔵 Fable 5 |
+| C | [LIB-007](./LIB-007-PUBLISHING-THE-SHELF.md) | Publishing the shelf stops being a manual copy | — | **UNASSIGNED** |
+| C | [LIB-008](./LIB-008-THE-DOCS-ORIGIN-IS-A-404.md) | Every documentation link in the shipped editor is a 404 | — | **UNASSIGNED** |
+
+🔴 **Sprint C was opened on 2026-09-11, the day v0.2.3 shipped, by two things that release
+exposed.** LIB-007: six parts were authored, gated, drive-tested, named in the public release notes
+and **published nowhere** — the release notes carry a caveat saying so, and removing that sentence
+is the acceptance criterion. LIB-008: `getDocsEndpoint` still names a Pages site that was renamed
+on 2026-08-07 and is a hard 404, so every in-editor docs link has been dead since. Both are the
+same shape — *an origin moved and only some of the callers were told* — which is why they sit
+together. **No time estimates: dependency order only** (standing rule, phase 77).
 
 **Anytime fixes** (independent, land immediately, don't wait for their parent task): the import-from-URL untick bug (LIB-004 step 0), the `startsWith` loader bug (LIB-003 step 0), loud fetch failure in the library tabs (LIB-001 step 0).
 

--- a/library/README.md
+++ b/library/README.md
@@ -188,18 +188,37 @@ point is that "no icon at all" is never the reason an entry cannot ship.
 
 ## Publish
 
-Publishing = copying the contents of `library-dist/` over the docs repo's
-`library/` path:
+Publishing = copying the contents of `library-dist/` over the content repo's
+`static/library/` path:
 
 ```
-library-dist/prefabs/*  ->  <docs-repo>/library/prefabs/
-library-dist/modules/*  ->  <docs-repo>/library/modules/
+library-dist/prefabs/*  ->  nodegx-content/static/library/prefabs/
+library-dist/modules/*  ->  nodegx-content/static/library/modules/
 ```
 
-This is a manual step today (no docs-repo write access from CI here). Record
-every publish as a dated entry in
+**Run the `Publish library` workflow** — Actions → *Publish library* → *Run
+workflow*, giving a one-line reason. It builds `library-dist/`, refuses to push
+anything `library:verify-dist` rejects, copies the built tree over
+`nodegx-content`, and then proves the result by fetching the **served** index
+through the editor's own `getContentEndpoint()`. Anyone with repo access can
+run it; no local checkout of `nodegx-content` is needed by anybody.
+
+It was a person copying a folder between two repositories until LIB-007, and on
+2026-09-11 that person was busy cutting a release — so 0.2.3 shipped six parts
+that were authored, gated, rendered and named in the public release notes, and
+that nobody could install.
+
+🔴 **`GITHUB_TOKEN` cannot write to a second repository.** The workflow uses
+`NODEGX_CONTENT_DEPLOY_KEY`, a write deploy key bound to `nodegx-content` and
+nothing else. That is the one genuinely new piece; the rest was always just a
+copy.
+
+The workflow opens a pull request refreshing
+[`scripts/library/origin-baseline.json`](../scripts/library/origin-baseline.json)
+afterwards, because a publish moves the divergence that file records. Its
+`$comment` is still yours to write. Record the publish as a dated entry in
 [PROGRESS.md](../dev-docs/tasks/phase-21-library-and-import/PROGRESS.md) under
-**Log**, noting which entries changed version.
+**Log**, naming the content-repo commit and which entries changed version.
 
 For local dev, `library:build`'s output can be served at the same path the
 dev editor already knows how to point at (`useLocalDocs` → `localhost:3000`,

--- a/scripts/library/verify-origin.ts
+++ b/scripts/library/verify-origin.ts
@@ -68,10 +68,13 @@
  *
  * Usage:
  *   npm run library:verify-origin
- *   ts-node -P ./scripts/tsconfig.json ./scripts/library/verify-origin.ts [--json] [--update-baseline]
+ *   npm run library:verify-origin -- --require-published
+ *   ts-node -P ./scripts/tsconfig.json ./scripts/library/verify-origin.ts \
+ *     [--json] [--update-baseline] [--require-published]
  *
- * Exit codes: 0 = matches the baseline, 1 = divergence changed, 2 = origin
- * unavailable or usage/IO error.
+ * Exit codes: 0 = matches the baseline (or, under --require-published, nothing
+ * authored is unreachable), 1 = divergence changed (or something authored is
+ * unreachable), 2 = origin unavailable or usage/IO error.
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -115,6 +118,32 @@ type LibraryType = (typeof TYPES)[number];
 const argv = process.argv.slice(2);
 const AS_JSON = argv.includes('--json');
 const UPDATE_BASELINE = argv.includes('--update-baseline');
+
+/**
+ * LIB-007 — the second question.
+ *
+ * The baseline above answers *"has the divergence CHANGED?"*. It does that
+ * correctly and it is not what failed. **Nothing owned *"is everything we
+ * authored actually REACHABLE?"***, which is how 0.2.3 shipped six parts that
+ * were authored, gated, rendered, drive-tested and named in the public release
+ * notes while being absent from the origin the editor fetches. Five of the six
+ * printed `known`; the run was red, and a run that has been red for days reads
+ * as furniture.
+ *
+ * A baseline that records "not published yet" cannot also be the thing that
+ * tells you to publish. So this mode **does not consult the baseline for its
+ * verdict**: any unpublished entry fails, whether or not somebody wrote it
+ * down. That is the whole point — writing it down is what made it invisible.
+ *
+ * Orphans are reported and deliberately **not** gated. A published entry with
+ * no source under `library/` is a tidiness problem; it is not a part nobody can
+ * install. Gating both would put this question back inside the first one.
+ *
+ * Run it where the claim is made: the publish workflow runs it against the
+ * served index after pushing, and the release workflow runs it before a tag is
+ * cut.
+ */
+const REQUIRE_PUBLISHED = argv.includes('--require-published');
 
 const ATTEMPTS = 3;
 const TIMEOUT_MS = 20_000;
@@ -299,11 +328,61 @@ async function main() {
     };
   }
 
+  if (REQUIRE_PUBLISHED) {
+    const missing = TYPES.flatMap((type) => divergence.unpublished[type].map((label) => ({ type, label })));
+    const orphans = TYPES.flatMap((type) => divergence.orphaned[type].map((label) => ({ type, label })));
+
+    if (AS_JSON) {
+      console.log(JSON.stringify({ endpoint, counts, missing, orphans }, null, 2));
+      process.exit(missing.length ? 1 : 0);
+    }
+
+    console.log(`Origin: ${endpoint}`);
+    console.log(`REACHABILITY — every entry under library/ must have a published counterpart.`);
+    console.log(`   ${path.relative(REPO_ROOT, BASELINE_PATH)} is NOT consulted: a divergence someone wrote down`);
+    console.log(`   is still a part nobody can install. That is LIB-007's whole finding.`);
+    console.log('');
+    for (const type of TYPES) {
+      const c = counts[type];
+      console.log(`${type}: library/ ${c.local}, origin ${c.origin}, sharing ${c.shared} labels`);
+    }
+    console.log('');
+    for (const { type, label } of orphans) {
+      console.log(`  note          [${type}] published with no source under library/: ${label}`);
+    }
+    if (missing.length) {
+      for (const { type, label } of missing) {
+        console.log(`  🔴 UNREACHABLE [${type}] ${label} — authored here, absent from the origin.`);
+      }
+      console.error(
+        `\n🔴 ${missing.length} ${missing.length === 1 ? 'entry is' : 'entries are'} authored under library/ ` +
+          `and cannot be installed by anyone.\n` +
+          `Publish them — run the "Publish library" workflow (.github/workflows/publish-library.yml),\n` +
+          `which builds library-dist/, gates it with library:verify-dist, and pushes to nodegx-content.`
+      );
+    } else {
+      console.log(`\nEvery entry under library/ is published at the origin. Nothing authored here is unreachable.`);
+      console.log(`🔴 Still COVERAGE BY LABEL — this does not say the published payload is library/'s payload.`);
+    }
+    process.exit(missing.length ? 1 : 0);
+  }
+
   if (UPDATE_BASELINE) {
     const existing: Baseline = JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8'));
-    const next: Baseline = { ...existing, unpublished: divergence.unpublished, orphaned: divergence.orphaned };
+    // `measuredOn` is stamped here rather than left for a human to remember:
+    // this file has just been rewritten from a measurement taken seconds ago, and
+    // a rewritten file carrying an older date is simply wrong. LIB-007 also needs
+    // the publish workflow to regenerate it unattended, which rules out a hand edit.
+    // The `$comment` is still the author's to write — that is the WHY, and no
+    // script can supply it.
+    const next: Baseline = {
+      ...existing,
+      measuredOn: new Date().toISOString().slice(0, 10),
+      unpublished: divergence.unpublished,
+      orphaned: divergence.orphaned
+    };
     fs.writeFileSync(BASELINE_PATH, JSON.stringify(next, null, 2) + '\n');
-    console.log(`Wrote ${path.relative(REPO_ROOT, BASELINE_PATH)}. 🔴 Update "measuredOn" and say WHY in the commit.`);
+    console.log(`Wrote ${path.relative(REPO_ROOT, BASELINE_PATH)} (measuredOn ${next.measuredOn}). 🔴 Say WHY in the commit.`);
     process.exit(0);
   }
 


### PR DESCRIPTION
**0.2.3 shipped six parts nobody can install.** Advanced Columns, Format Date, Format Full Name, Sanitise Email, Charts and Media Recorder are authored, gated, rendered, drive-tested and named in the public release notes — and absent from the origin the editor actually fetches. The release notes carry a caveat saying so.

The gap was never the work. The gap is that publishing was a person copying `library-dist/` between two repositories, and on 2026-09-11 that person was busy shipping a release.

Closes the machinery half of [LIB-007](dev-docs/tasks/phase-21-library-and-import/LIB-007-PUBLISHING-THE-SHELF.md). **It does not publish anything yet** — see *What still has to happen*.

## Two things, and the second is the one worth having

### 1. `.github/workflows/publish-library.yml`

`workflow_dispatch`, so anyone with repo access can publish with no local checkout of `nodegx-content` anywhere in the loop. It builds, gates with `library:verify-dist` **before the credential is ever read**, copies the built tree over the content repo, then proves the result by fetching the **served** index through the editor's own `getContentEndpoint()`, and opens a PR refreshing `origin-baseline.json` — because a publish moves what that file records.

🔴 `GITHUB_TOKEN` cannot write to a second repository. That is the whole reason the step was manual.

### 2. `library:verify-origin --require-published`, and a Release job that runs it

The existing gate did not miss this; **it is not the gate for it.** `origin-baseline.json` records the divergence *as measured* and answers *"has the divergence CHANGED?"* — correctly, and that is D21's job. Five of the six missing parts were written down in it, so they printed `known` on a run that had been red for days, which is the state in which a red run reads as furniture.

A baseline that records "not published yet" cannot also be the thing that tells you to publish.

So `--require-published` does not consult the baseline at all: any entry under `library/` with no published counterpart fails. It runs on a version tag, deliberately without `needs:` on the packaging matrix, so it answers in a minute rather than ninety and can never hold up an urgent fix. What it does is turn the release run red next to a draft a human still has to press publish on.

## What was measured, not assumed

| | |
|---|---|
| The gate discriminates in the red direction | `--require-published` names all six and exits 1, run **before** anything here changed |
| `verify-dist` refuses a bad build | Armed an entry with `minEditorVersion: 99.0.0` → exit 1, names the entry. A gate that has never failed has not been tested |
| Blast radius of the publish | Exactly 12 new files (the six parts + icons) and the two `index.json`. Nothing else is touched |
| Clone cost | 951 MB plain → 422 MB sparse+blobless, of which 228 MB is the payload itself |
| `nodegx-content` Pages is still `build_type: legacy` | `gh api .../pages` — the `/static` suffix in `getContentEndpoint.ts` still resolves |

## 🔴 One finding worth reading before merging

`nodegx-content`'s `.github/workflows/pages.yaml` is **active** and triggers on every push to `main`. It would rebuild the site as Docusaurus and flatten `static/**` to the site root — 404-ing every URL the editor builds.

It has run on every publish already, manual ones included, and **failed at `npm run build` every time since 2025-12-06**. That failure is the only thing currently preserving the `/static` suffix.

No cross-repo credential can suppress another repo's `on: push` trigger, so this workflow does not try to dodge it. It does something better: the reachability assertion fetches the *served* index, so if that Docusaurus build is ever fixed and flips the site, the publish goes red with an UNAVAILABLE origin instead of quietly succeeding. **The trap is armed rather than avoided.** A deliberate flip is ALPHA-006 B5's, and it moves the suffix in `getContentEndpoint.ts` in the same change.

## What still has to happen

1. **Merge this** — GitHub only registers `workflow_dispatch` from the default branch, so the workflow cannot be run at all until it is on `main` (confirmed: HTTP 404 dispatching from `cline-dev`).
2. **Create the credential** — three commands, written up in [RELEASE-PROCESS.md §1e](dev-docs/guidelines/RELEASE-PROCESS.md).
3. **Run the workflow**, which publishes the six and makes AC1–AC3 true.
4. **Then** delete the caveat from the v0.2.3 release notes, and add the dated PROGRESS.md entry naming the content-repo commit.

Until 3 happens the six parts are still unreachable and the caveat in the release notes is still true, which is why it is still there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)